### PR TITLE
rename mod to comply with naming convention

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
 				"GitHub.copilot",
 				"GitHub.copilot-chat",
 				"tamasfe.even-better-toml",
-				"xTeal.mcmeta"
+				"xTeal.mcmeta",
+				"vscjava.vscode-java-pack"
 			]
 		}
 	},

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'maven-publish'
 
 version = '1.16.5-0.36.0.0' // Using ForgeMaven Versionin https://docs.minecraftforge.net/en/latest/gettingstarted/versioning/
-group = 'com.davisodom.villagesMod' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = 'villagesMod'
+group = 'com.davisodom.villages_mod' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+archivesBaseName = 'villages_mod'
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(8) // Mojang ships Java 8 to end users, so your mod should target Java 8.
 
@@ -54,7 +54,7 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             mods {
-                villagesMod {
+                villages_mod {
                     source sourceSets.main
                 }
             }
@@ -76,7 +76,7 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             mods {
-                villagesMod {
+                villages_mod {
                     source sourceSets.main
                 }
             }
@@ -98,10 +98,10 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             // Specify the modid for data generation, where to output the resulting resource, and where to look for existing resources.
-            args '--mod', 'villagesMod', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+            args '--mod', 'villages_mod', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
 
             mods {
-                villagesMod {
+                villages_mod {
                     source sourceSets.main
                 }
             }
@@ -142,7 +142,7 @@ dependencies {
 jar {
     manifest {
         attributes([
-            "Specification-Title": "villagesMod",
+            "Specification-Title": "villages_mod",
             "Specification-Vendor": "Davis Odom",
             "Specification-Version": "1", // We are version 1 of ourselves
             "Implementation-Title": project.name,

--- a/src/main/java/com/example/examplemod/villages_mod.java
+++ b/src/main/java/com/example/examplemod/villages_mod.java
@@ -1,4 +1,4 @@
-package com.example.villagesMod;
+package com.example.villages_mod;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
@@ -19,13 +19,13 @@ import org.apache.logging.log4j.Logger;
 import java.util.stream.Collectors;
 
 // The value here should match an entry in the META-INF/mods.toml file
-@Mod("villagesMod")
-public class villagesMod
+@Mod("villages_mod")
+public class villages_mod
 {
     // Directly reference a log4j logger.
     private static final Logger LOGGER = LogManager.getLogger();
 
-    public villagesMod() {
+    public villages_mod() {
         // Register the setup method for modloading
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
         // Register the enqueueIMC method for modloading
@@ -54,7 +54,7 @@ public class villagesMod
     private void enqueueIMC(final InterModEnqueueEvent event)
     {
         // some example code to dispatch IMC to another mod
-        InterModComms.sendTo("villagesMod", "helloworld", () -> { LOGGER.info("Hello world from the MDK"); return "Hello world";});
+        InterModComms.sendTo("villages_mod", "helloworld", () -> { LOGGER.info("Hello world from the MDK"); return "Hello world";});
     }
 
     private void processIMC(final InterModProcessEvent event)

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -15,7 +15,7 @@ license="All rights reserved"
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
-modId="villagesMod" #mandatory
+modId="villages_mod" #mandatory
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
 # ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
 # see the associated build.gradle script for how to populate this completely automatically during a build
@@ -27,7 +27,7 @@ displayName="Example Mod" #mandatory
 # A URL for the "homepage" for this mod, displayed in the mod UI
 #displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional
 # A file name (in the root of the mod JAR) containing a logo for display
-logoFile="villagesMod.png" #optional
+logoFile="villages_mod.png" #optional
 # A text field displayed in the mod UI
 credits="Thanks for this example mod goes to Java" #optional
 # A text field displayed in the mod UI
@@ -41,7 +41,7 @@ Have some lorem ipsum.
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed mollis lacinia magna. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed sagittis luctus odio eu tempus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Pellentesque volutpat ligula eget lacus auctor sagittis. In hac habitasse platea dictumst. Nunc gravida elit vitae sem vehicula efficitur. Donec mattis ipsum et arcu lobortis, eleifend sagittis sem rutrum. Cras pharetra quam eget posuere fermentum. Sed id tincidunt justo. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 '''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-[[dependencies.villagesMod]] #optional
+[[dependencies.villages_mod]] #optional
     # the modid of the dependency
     modId="forge" #mandatory
     # Does this dependency have to exist - if not, ordering below must be specified
@@ -53,7 +53,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed mollis lacinia magn
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
     side="BOTH"
 # Here's another dependency
-[[dependencies.villagesMod]]
+[[dependencies.villages_mod]]
     modId="minecraft"
     mandatory=true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "description": "villagesMod resources",
+        "description": "villages_mod resources",
         "pack_format": 6,
         "_comment": "A pack_format of 6 requires json lang files and some texture changes from 1.16.2. Note: we require v6 pack meta for all mods."
     }


### PR DESCRIPTION
This pull request includes changes to standardize the naming convention of the `villages_mod` package and update the development environment configuration.

### Naming Convention Standardization:

* Renamed `src/main/java/com/example/examplemod/villagesMod.java` to `src/main/java/com/example/examplemod/villages_mod.java` and updated the package name to `com.example.villages_mod`. (`[src/main/java/com/example/examplemod/villages_mod.javaL1-R1](diffhunk://#diff-efd3d02969e74d0fed3436ba243f824693802fe7cf57d6f8c65e253743ee69bcL1-R1)`)
* Updated the `@Mod` annotation and class name from `villagesMod` to `villages_mod` in `src/main/java/com/example/examplemod/villages_mod.java`. (`[src/main/java/com/example/examplemod/villages_mod.javaL22-R28](diffhunk://#diff-efd3d02969e74d0fed3436ba243f824693802fe7cf57d6f8c65e253743ee69bcL22-R28)`)
* Changed the `InterModComms.sendTo` method to use `villages_mod` instead of `villagesMod` in `src/main/java/com/example/examplemod/villages_mod.java`. (`[src/main/java/com/example/examplemod/villages_mod.javaL57-R57](diffhunk://#diff-efd3d02969e74d0fed3436ba243f824693802fe7cf57d6f8c65e253743ee69bcL57-R57)`)
* Updated `modId` and `logoFile` entries in `src/main/resources/META-INF/mods.toml` to `villages_mod`. (`[[1]](diffhunk://#diff-3bc2a2f6cb6e625914eaf245e536e39108fbc2a24acd076bd6bbc2a60f56c214L18-R18)`, `[[2]](diffhunk://#diff-3bc2a2f6cb6e625914eaf245e536e39108fbc2a24acd076bd6bbc2a60f56c214L30-R30)`)
* Modified dependencies in `src/main/resources/META-INF/mods.toml` to reference `villages_mod`. (`[[1]](diffhunk://#diff-3bc2a2f6cb6e625914eaf245e536e39108fbc2a24acd076bd6bbc2a60f56c214L44-R44)`, `[[2]](diffhunk://#diff-3bc2a2f6cb6e625914eaf245e536e39108fbc2a24acd076bd6bbc2a60f56c214L56-R56)`)
* Changed the description in `src/main/resources/pack.mcmeta` to `villages_mod resources`. (`[src/main/resources/pack.mcmetaL3-R3](diffhunk://#diff-642054513e7de2917f4edb6d7a1b348b9ffc07662df15f7af08bca9b7d849e9dL3-R3)`)

### Development Environment Configuration:

* Added the `vscjava.vscode-java-pack` extension to the `.devcontainer/devcontainer.json` file. (`[.devcontainer/devcontainer.jsonL22-R23](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L22-R23)`)