### PR TITLE
Rename package and dirs to com.davisodom.villages_mod

### DIFF
--- a/src/main/java/com/davisodom/villages_mod/villages_mod.java
+++ b/src/main/java/com/davisodom/villages_mod/villages_mod.java
@@ -1,4 +1,4 @@
-package com.example.villages_mod;
+package com.davisodom.villages_mod;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;


### PR DESCRIPTION
This pull request includes a small but significant change to the package structure of the `villages_mod` project. The package name has been updated to reflect the new ownership.

* [`src/main/java/com/davisodom/villages_mod/villages_mod.java`](diffhunk://#diff-228fc87607e1848cb0d503da8e83a6f710298c4524fe668b204d155df74972b0L1-R1): Renamed the package from `com.example.villages_mod` to `com.davisodom.villages_mod`.